### PR TITLE
Add pull request template

### DIFF
--- a/PULL_REQUEST_TEMPLATE/bugfix_template.md
+++ b/PULL_REQUEST_TEMPLATE/bugfix_template.md
@@ -1,0 +1,8 @@
+# Checklist for Bugfixes
+
+- [ ] I have ensured my code follows the [style guidelines](https://github.com/jasp-stats/jasp-desktop/blob/stable/Docs/development/r-style-guide.md).
+- [ ] I have added a linked issue #(issue number) in the pull request 
+  - Example: 'Fixes #1234', or 'Fixes jasp-stats/INTERNAL-jasp#1234' ([Documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)).
+- [ ] I have added changes to `NEWS.md` under the heading bugfixes.
+- [ ] I have added a unit test, or else an explanation why no test is needed. 
+  -  Example: 'this bug is only reproducible in Jasp because it has to do with the state.'

--- a/PULL_REQUEST_TEMPLATE/bugfix_template.md
+++ b/PULL_REQUEST_TEMPLATE/bugfix_template.md
@@ -1,8 +1,0 @@
-# Checklist for Bugfixes
-
-- [ ] I have ensured my code follows the [style guidelines](https://github.com/jasp-stats/jasp-desktop/blob/stable/Docs/development/r-style-guide.md).
-- [ ] I have added a linked issue #(issue number) in the pull request 
-  - Example: 'Fixes #1234', or 'Fixes jasp-stats/INTERNAL-jasp#1234' ([Documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)).
-- [ ] I have added changes to `NEWS.md` under the heading bugfixes.
-- [ ] I have added a unit test, or else an explanation why no test is needed. 
-  -  Example: 'this bug is only reproducible in Jasp because it has to do with the state.'

--- a/PULL_REQUEST_TEMPLATE/pr_template.md
+++ b/PULL_REQUEST_TEMPLATE/pr_template.md
@@ -1,0 +1,28 @@
+# Checklist for Pull Requests
+
+- [ ] I have ensured my code follows the [style guidelines](https://github.com/jasp-stats/jasp-desktop/blob/stable/Docs/development/r-style-guide.md).
+<!---
+-->
+- [ ] I have added a linked issue #(issue number) in the pull request 
+<!---
+Example: 'Fixes #1234', or 'Fixes jasp-stats/INTERNAL-jasp#1234'.
+See the documentation at https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
+-->
+- [ ] I have added changes to `NEWS.md` under the appropriate heading
+<!---
+  - 'Major changes' - if the pull request changed the default functionality of an analysis changes or adds a large new feature.
+    - Examples of major changes: 
+      - Addition of GORICA to jaspANOVA (large feature). 
+      - Addition of GLM to jaspRegression (new analysis).
+  - 'Minor changes' - if the pull request changed the default functionality of an analysis changes or adds a large new feature.
+    - Examples of minor changes:
+      - Adding a dropdown with new options to specify histogram bins jaspDescriptives.
+      - Adding a new plot to jaspRegression.
+  - 'Bugfixes'
+    - Example
+      - The variance check in the ANOVA was too strict.
+-->
+- [ ] I have added unit tests or an explanation why no tests are needed.
+<!---
+Example: 'this bug is only reproducible in Jasp because it has to do with the state.'
+-->

--- a/PULL_REQUEST_TEMPLATE/pr_template.md
+++ b/PULL_REQUEST_TEMPLATE/pr_template.md
@@ -22,6 +22,12 @@ See the documentation at https://docs.github.com/en/issues/tracking-your-work-wi
     - Example
       - The variance check in the ANOVA was too strict.
 -->
+- [ ] I have updated the help files, if appropriate.
+<!---
+The help files are in inst/help.
+Please update these if you add any new features, no matter how small.
+Also use e.g., deepl to update the translated help files.
+-->
 - [ ] I have added unit tests or an explanation why no tests are needed.
 <!---
 Example: 'this bug is only reproducible in Jasp because it has to do with the state.'


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/345, Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1207

I decided to add the examples as comments so they wouldn't cause a lot of clutter. Also initially I considered making two templates, one for bugfixes and one for features. In the end, I decided against this because they were too similar.