### PR TITLE
Create .gitattributes to ignore *.po files for detecting the programming language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.po linguist-detectable=true
+*.1 linguist-detectable=false


### PR DESCRIPTION
Supersedes https://github.com/jasp-stats/jaspBase/pull/69 by @shun2wang.
